### PR TITLE
chore: Fix identity-service-sdk version

### DIFF
--- a/agent/a2a/currency_exchange/pyproject.toml
+++ b/agent/a2a/currency_exchange/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "langchain-mcp-adapters>=0.0.7",
     "langchain-openai>=0.2.0",
     "langgraph>=0.3.29",
-    "identity-service-sdk",
+    "identity-service-sdk=0.0.2",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/agent/oasf/financial_assistant/pyproject.toml
+++ b/agent/oasf/financial_assistant/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "langchain-mcp-adapters>=0.0.7",
     "langchain-openai>=0.3.1",
     "langgraph>=0.3.29",
-    "identity-service-sdk",
+    "identity-service-sdk=0.0.2",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
# Description

Set the version of the identity-service-sdk before A2A support for v0.3.*

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/cisco-outshift-ai-agents/identity-service-samples/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
